### PR TITLE
fix(totems): keep speakers in totems display before fade out

### DIFF
--- a/src/remotion/compositions/showcases/devfestNantes/DevfestNantesLoopTotem.tsx
+++ b/src/remotion/compositions/showcases/devfestNantes/DevfestNantesLoopTotem.tsx
@@ -77,11 +77,6 @@ export const DevfestNantesLoopTotem = ({
 		},
 	);
 
-	const SlideDown = interpolate(frame, [300, 330], [0, 650], {
-		extrapolateRight: 'clamp',
-		extrapolateLeft: 'clamp',
-		easing: Easing.bezier(0.51, -0.75, 0.99, 0.75),
-	});
 
 	return (
 		<AbsoluteFill
@@ -179,7 +174,6 @@ export const DevfestNantesLoopTotem = ({
 			<div
 				style={{
 					height: '100%',
-					transform: `translateY(${SlideDown}px)`,
 				}}
 			>
 				<Sequence name="Speakers" from={135}>


### PR DESCRIPTION
As discussed in slack, speaker strangely disapear at the end of animation.